### PR TITLE
Update TYPO3 dependency version

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = array(
     'constraints' => array(
         'depends' => array(
             'php' => '5.3.0-7.0.99',
-            'typo3' => '6.2.0-7.9.99',
+            'typo3' => '6.2.0-8.9.99',
         ),
         'conflicts' => array(),
         'suggests' => array(),


### PR DESCRIPTION
mfc_canonical seems to be compatible with TYPO3 8.7 as well. So you may want to update the TYPO3 dependency version.