### PR TITLE
Add signal to Canonical class

### DIFF
--- a/Classes/User/Canonical.php
+++ b/Classes/User/Canonical.php
@@ -20,6 +20,7 @@ namespace Mfc\MfcCanonical\User;
 
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 
 /**
  * Contoller for imports
@@ -43,6 +44,8 @@ class Canonical
      *
      * @param string $content
      * @param array $conf
+     * @throws \TYPO3\CMS\Extbase\SignalSlot\Exception\InvalidSlotException
+     * @throws \TYPO3\CMS\Extbase\SignalSlot\Exception\InvalidSlotReturnException
      */
     public function render($content, $conf)
     {
@@ -51,7 +54,13 @@ class Canonical
 
         $host = $this->getHost($content, $this->conf);
         if (!empty($host)) {
-            $this->pageRenderer->addMetaTag('<link rel="canonical" href="' . $this->getUrl($content, $conf) . '"/>');
+            $url = $this->getUrl($content, $conf);
+
+            /** @var Dispatcher $signalSlotDispatcher */
+            $signalSlotDispatcher = GeneralUtility::makeInstance(Dispatcher::class);
+            $signalSlotDispatcher->dispatch(Canonical::class, 'customizeUrl', [$content, $this->conf, $host, &$url]);
+
+            $this->pageRenderer->addMetaTag('<link rel="canonical" href="' . $url . '">');
         }
     }
 


### PR DESCRIPTION
It should be possible to change the canonical from extensions. Imagine, you have an extension with list items. These list items have separate single pages and can be included into other pages. To avoid duplicate content these single items (which are included) should point to the page including an item.

The pull request implements a signal, so the canonical url can be changed in an extension with a slot.

Definition of slot in own extension (`ext_localconf.php`):
```php
$signalSlotDispatcher = TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
$signalSlotDispatcher->connect(
    Mfc\MfcCanonical\User\Canonical::class,
    'customizeUrl',
    Vendor\Extension\Slot\CanonicalSlot::class,
    'customizeUrl'
);
```

And an exemplary implementation:
```php
namespace Vendor\Extension\Slot;

class CanonicalSlot
{
    public function customizeUrl($content, $conf, $host, &$url)
    {
        // some logic

        if ($canonicalShouldBeChanged) {
            $url = 'http://example.org/some/other/path/';
        }
    }
}
```

The `url` parameter ist called by reference and can thereby be changed.

I would appreciate it if this change would be merged into the extension.